### PR TITLE
fix query can automatically treat null clause depends on value

### DIFF
--- a/src/main/java/com/iciql/QueryCondition.java
+++ b/src/main/java/com/iciql/QueryCondition.java
@@ -60,7 +60,11 @@ public class QueryCondition<T, A> {
     }
 
     public QueryWhere<T> is(A y) {
-        query.addConditionToken(new Condition<A>(x, y, CompareType.EQUAL));
+        if (y == null) {
+            query.addConditionToken(new Condition<A>(x, CompareType.IS_NULL));
+        } else {
+            query.addConditionToken(new Condition<A>(x, y, CompareType.EQUAL));
+        }
         return new QueryWhere<T>(query);
     }
 


### PR DESCRIPTION
Isn't it better that Iciql can automatically treat query condition of value NULL.

When use NULL value with interface like below

```
Db.open('con').from(r).where(r.column).is(value)...
```

this create raw sql like below

```
select columns from r where column = null...;
```

this where clause doesn't affect anything. 
actually this should be 

```
select columns from r where column is NULL...;
```

