### PR TITLE
Avoid NullPointerException

### DIFF
--- a/src/main/java/com/iciql/TableInspector.java
+++ b/src/main/java/com/iciql/TableInspector.java
@@ -115,6 +115,7 @@ public class TableInspector {
             while (rs.next()) {
                 IndexInspector info = new IndexInspector(rs);
                 if (info.type.equals(IndexType.UNIQUE)) {
+                    if(info.name == null) continue;
                     String name = info.name.toLowerCase();
                     if (name.startsWith("primary") || name.startsWith("sys_idx_sys_pk")
                             || name.startsWith("sql") || name.endsWith("_pkey")) {


### PR DESCRIPTION
Some JDBC drivers (db2cc 10.1.0.1) in my case yield strange infos. Just ignore them.