### PR TITLE
simple join select

### DIFF
--- a/src/main/java/com/iciql/Query.java
+++ b/src/main/java/com/iciql/Query.java
@@ -295,7 +295,7 @@ public class Query<T> {
             def.appendSelectList(stat, from.getAs());
         } else {
             def.appendSelectList(stat);
-         }
+        }
         appendFromWhere(stat);
         ResultSet rs = stat.executeQuery();
         try {

--- a/src/main/java/com/iciql/Query.java
+++ b/src/main/java/com/iciql/Query.java
@@ -291,7 +291,11 @@ public class Query<T> {
         List<T> result = Utils.newArrayList();
         TableDefinition<T> def = from.getAliasDefinition();
         SQLStatement stat = getSelectStatement(distinct);
-        def.appendSelectList(stat);
+        if (isJoin()) {
+            def.appendSelectList(stat, from.getAs());
+        } else {
+            def.appendSelectList(stat);
+         }
         appendFromWhere(stat);
         ResultSet rs = stat.executeQuery();
         try {

--- a/src/main/java/com/iciql/TableDefinition.java
+++ b/src/main/java/com/iciql/TableDefinition.java
@@ -1150,6 +1150,17 @@ public class TableDefinition<T> {
         }
     }
 
+    void appendSelectList(SQLStatement stat, String as) {
+        for (int i = 0; i < fields.size(); i++) {
+            if (i > 0) {
+                stat.appendSQL(", ");
+            }
+            stat.appendSQL(as + ".");
+            FieldDefinition def = fields.get(i);
+            stat.appendColumn(def.columnName);
+        }
+    }
+
     <Y, X> void appendSelectList(SQLStatement stat, Query<Y> query, X x) {
         // select t0.col1, t0.col2, t0.col3...
         // select table1.col1, table1.col2, table1.col3...

--- a/src/test/java/com/iciql/test/JoinTest.java
+++ b/src/test/java/com/iciql/test/JoinTest.java
@@ -73,6 +73,7 @@ public class JoinTest {
         List<UserId> userIds = db.from(u).innerJoin(n).on(u.id).is(n.userId).where(n.text).is("D")
                 .select();
         assertEquals(1, userIds.size());
+        assertEquals(1, userIds.get(0).id);
     }
 
     @Test

--- a/src/test/java/com/iciql/test/JoinTest.java
+++ b/src/test/java/com/iciql/test/JoinTest.java
@@ -58,11 +58,21 @@ public class JoinTest {
                 .select(new UserNote() {
                     {
                         userId = n.userId;
-                        noteId = n.noteId;
+                        id = n.id;
                         text = n.text;
                     }
                 });
         assertEquals(3, notes.size());
+    }
+
+    @Test
+    public void testPrimitiveJoinAndSimpleSelect() throws Exception {
+        final UserId u = new UserId();
+        final UserNote n = new UserNote();
+
+        List<UserId> userIds = db.from(u).innerJoin(n).on(u.id).is(n.userId).where(n.text).is("D")
+                .select();
+        assertEquals(1, userIds.size());
     }
 
     @Test
@@ -140,7 +150,7 @@ public class JoinTest {
     public static class UserNote {
 
         @IQColumn(autoIncrement = true, primaryKey = true)
-        public int noteId;
+        public int id;
 
         @IQColumn
         public int userId;


### PR DESCRIPTION
I want to do this.

## SQL
```
select id,name from book;
select id,book_id,count from stock;
↓ join select (stock count = 0)
select T1.id, T1.name from book T1 inner join stock T2 on T1.id = T2.book_id where T2.count = 0;
```

## iciql
```
Book b = new Book();
Stock s = new Stock();
db.from(b).innerJoin(s).on(b.id).is(s.book_id).where(b.count).is(0).select();

However, an error has occurred. Ambiguous column name "ID".
```

For "simple join select", I added a table alias to the column name.