### PR TITLE
This will get a dto containing the enum as the result of the select.

### DIFF
--- a/src/main/java/com/iciql/Query.java
+++ b/src/main/java/com/iciql/Query.java
@@ -917,6 +917,37 @@ public class Query<T> {
     /**
      * INTERNAL
      *
+     * @param stat  the statement
+     * @param alias the alias object (can be null)
+     * @param value the value
+     */
+    public void appendSelectSQL(SQLStatement stat, Object alias, Object value) {
+        if (Function.count() == value) {
+            stat.appendSQL("COUNT(*)");
+            return;
+        }
+        if (RuntimeParameter.PARAMETER == value) {
+            stat.appendSQL("?");
+            addParameter(stat, alias, value);
+            return;
+        }
+        Token token = Db.getToken(value);
+        if (token != null) {
+            token.appendSQL(stat, this);
+            return;
+        }
+        SelectColumn<T> col = getColumnByReference(value);
+        if (col != null) {
+            col.appendSQL(stat);
+            return;
+        }
+        stat.appendSQL("?");
+        addParameter(stat, alias, value);
+    }
+
+    /**
+     * INTERNAL
+     *
      * @param stat        the statement
      * @param alias       the alias object (can be null)
      * @param valueLeft   the value on the left of the compound clause

--- a/src/main/java/com/iciql/TableDefinition.java
+++ b/src/main/java/com/iciql/TableDefinition.java
@@ -1185,10 +1185,10 @@ public class TableDefinition<T> {
             if (def.isPrimitive) {
                 Object obj = def.getValue(x);
                 Object alias = query.getPrimitiveAliasByValue(obj);
-                query.appendSQL(stat, x, alias);
+                query.appendSelectSQL(stat, x, alias);
             } else {
                 Object obj = def.getValue(x);
-                query.appendSQL(stat, x, obj);
+                query.appendSelectSQL(stat, x, obj);
             }
         }
     }

--- a/src/test/java/com/iciql/test/models/EnumModels.java
+++ b/src/test/java/com/iciql/test/models/EnumModels.java
@@ -220,4 +220,9 @@ public abstract class EnumModels {
                     new EnumStringModel(100, Tree.PINE, Genus.PINUS));
         }
     }
+
+    public static class EnumJoin {
+        public Integer id;
+        public Genus genus;
+    }
 }


### PR DESCRIPTION
I want to do this.

SQL
```
select id,name from book;
select id,book_id,count,kind from stock; // kind is enum
↓ join select
select T1.id, T1.name, T2.kind from book T1 inner join stock T2 on T1.id = T2.book_id
```
iciql
```
Book b = new Book(); // entity
Stock s = new Stock(); // entity
db.from(b).innerJoin(s).on(b.id).is(s.book_id).select(
  new BookStock() { // dto
    {
      id = b.id;
      name = b.name;
      kind = s.kind; // kind is enum.
    }
});
```
However, an error has occurred.The cause is a ``special case`` of Query.java.
For ``select object enum``, I removed a ``special case``.

``appendSQL`` is used in ``select`` and ``where``.
Changed to use ``appendSelectSQL`` only for ``select``.
``appendSelectSQL``copies from ``appendSQL`` and removes only the enum handling.

This will get a dto containing the enum as the result of the select.
